### PR TITLE
fix: make domain_zone and domain_host variables optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@
 |------|-------------|------|---------|:--------:|
 | account\_name | The account or environment name | `string` | n/a | yes |
 | allowed\_ips\_list | List of IPs to allow on WAF and IAM Policies. Each IP must be in CIDR format (e.g., '192.168.1.0/24' or '10.0.0.1/32') | `list(string)` | n/a | yes |
-| domain\_host | The name of the Route 53 record | `string` | n/a | yes |
-| domain\_zone | Hosted Zone name of the desired Hosted Zone | `string` | n/a | yes |
+| domain\_host | (optional) The name of the Route 53 record | `string` | `""` | no |
+| domain\_zone | (optional) Hosted Zone name of the desired Hosted Zone | `string` | `""` | no |
 | endpoint\_type | PUBLIC or VPC | `string` | `"PUBLIC"` | no |
 | public\_subnet\_ids | List of public subnet IDs for VPC Endpoint. | `list(any)` | `[]` | no |
 | s3\_bucket\_name | The bucket name | `string` | n/a | yes |

--- a/_variables.tf
+++ b/_variables.tf
@@ -64,12 +64,14 @@ variable "public_subnet_ids" {
 }
 variable "domain_zone" {
   type        = string
-  description = "Hosted Zone name of the desired Hosted Zone"
+  default     = ""
+  description = "(optional) Hosted Zone name of the desired Hosted Zone"
 }
 
 variable "domain_host" {
   type        = string
-  description = "The name of the Route 53 record"
+  default     = ""
+  description = "(optional) The name of the Route 53 record"
 }
 
 variable "account_name" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -42,7 +42,7 @@ variable "sftp_users" {
 variable "allowed_ips_list" {
   type        = list(string)
   description = "List of IPs to allow on WAF and IAM Policies. Each IP must be in CIDR format (e.g., '192.168.1.0/24' or '10.0.0.1/32')"
-  
+
   validation {
     condition = alltrue([
       for ip in var.allowed_ips_list : can(cidrhost(ip, 0))
@@ -62,10 +62,15 @@ variable "public_subnet_ids" {
   default     = []
   description = "List of public subnet IDs for VPC Endpoint."
 }
+
 variable "domain_zone" {
   type        = string
   default     = ""
   description = "(optional) Hosted Zone name of the desired Hosted Zone"
+  validation {
+    condition     = var.domain_zone == "" || can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$", var.domain_zone))
+    error_message = "Domain zone must be a valid domain name or empty string"
+  }
 }
 
 variable "domain_host" {

--- a/route53.tf
+++ b/route53.tf
@@ -1,9 +1,11 @@
 data "aws_route53_zone" "selected" {
+  count = var.domain_zone != "" ? 1 : 0
   name = var.domain_zone
 }
 
 resource "aws_route53_record" "transfer-family" {
-  zone_id = data.aws_route53_zone.selected.zone_id
+  count = var.domain_zone != "" && var.domain_host != "" ? 1 : 0
+  zone_id = data.aws_route53_zone.selected[0].zone_id
   name    = var.domain_host
   type    = "CNAME"
   ttl     = "300"


### PR DESCRIPTION
- Add default empty string values to domain_zone and domain_host variables
- Route53 resources use conditional count based on variable values
- Fix test assertions to handle Route53 resources with count indexing
- Add comprehensive negative test cases for optional Route53 functionality
- All 10 tests now pass including 4 new negative test scenarios


Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...